### PR TITLE
Use latest version of actions/setup-node

### DIFF
--- a/.github/workflows/tests-and-code-style.yml
+++ b/.github/workflows/tests-and-code-style.yml
@@ -24,7 +24,7 @@ jobs:
                   php-version: ${{ matrix.php }}
 
             - name: Setup Node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
                   node-version: 18
 


### PR DESCRIPTION
This avoids GitHub's warning `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.` which appears as annotation although node-version is set to 18 already.