### PR TITLE
Don't empty file path if a booking is updated without file upload

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -37,6 +37,7 @@
     "Comment": "Kommentar",
     "Confirm": "Bestätigen",
     "Confirm password": "Passwort bestätigen",
+    "Could not save file for :name.": "Konnte Datei für :name nicht speichern.",
     "Country": "Land",
     "Create": "Erstellen",
     "Create booking option": "Anmeldeoption erstellen",


### PR DESCRIPTION
Bug introduced within initial implementation of file uploads in #17.