### PR TITLE
Fix group management via Livewire after update caused by duplicate loading of Alpine

### DIFF
--- a/resources/views/groups/group_index.blade.php
+++ b/resources/views/groups/group_index.blade.php
@@ -131,5 +131,4 @@
 
 @push('scripts')
     @livewireScripts
-    <script src="{{ mix('/lib/alpinejs.min.js') }}" defer></script>
 @endpush


### PR DESCRIPTION
Duplicate loading of Alpine breaks all features of the Livewire component after the recent updates.