### PR TITLE
Fix display of custom field options in groups overview

### DIFF
--- a/resources/views/livewire/groups/bookings.blade.php
+++ b/resources/views/livewire/groups/bookings.blade.php
@@ -86,7 +86,7 @@
                     @endif
                     @foreach($formFields as $formField)
                         <div class="small">
-                            <i class="fa fa-fw fa-file-lines"></i> {{ $formField->name }}: {{ $booking->getFieldValue($formField) ?? '—' }}
+                            <i class="fa fa-fw fa-file-lines"></i> {{ $formField->name }}: {{ $booking->getFieldValueAsText($formField) ?? '—' }}
                         </div>
                     @endforeach
                 </x-bs::list.item>


### PR DESCRIPTION
Caused error if an array (multiple checkboxes) is contained in the field list.