### PR TITLE
Fix and improve breadcrumbs

### DIFF
--- a/resources/views/booking_options/booking_option_form.blade.php
+++ b/resources/views/booking_options/booking_option_form.blade.php
@@ -14,8 +14,7 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('events.index') }}">{{ __('Events') }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('events.show', $event) }}">{{ $event->name }}</x-bs::breadcrumb.item>
+    @include('events.shared.event_breadcrumbs')
     @isset($bookingOption)
         <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
     @endisset

--- a/resources/views/booking_options/booking_option_show.blade.php
+++ b/resources/views/booking_options/booking_option_show.blade.php
@@ -12,8 +12,7 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('events.index') }}">{{ __('Events') }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('events.show', $event) }}">{{ $event->name }}</x-bs::breadcrumb.item>
+    @include('events.shared.event_breadcrumbs')
     <x-bs::breadcrumb.item>{{ $bookingOption->name }}</x-bs::breadcrumb.item>
 @endsection
 

--- a/resources/views/bookings/booking_form.blade.php
+++ b/resources/views/bookings/booking_form.blade.php
@@ -13,9 +13,12 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('events.index') }}">{{ __('Events') }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('events.show', $event) }}">{{ $event->name }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @include('events.shared.event_breadcrumbs')
+    @can('view', $bookingOption)
+        <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @else
+        <x-bs::breadcrumb.item>{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @endcan
     @can('viewBookings', $bookingOption)
         <x-bs::breadcrumb.item href="{{ route('bookings.index', [$event, $bookingOption]) }}">{{ __('Bookings') }}</x-bs::breadcrumb.item>
     @endcan

--- a/resources/views/bookings/booking_index_payments.blade.php
+++ b/resources/views/bookings/booking_index_payments.blade.php
@@ -14,9 +14,12 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('events.index') }}">{{ __('Events') }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('events.show', $event) }}">{{ $event->name }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @include('events.shared.event_breadcrumbs')
+    @can('view', $bookingOption)
+        <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @else
+        <x-bs::breadcrumb.item>{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @endcan
     @can('viewBookings', \App\Models\BookingOption::class)
         <x-bs::breadcrumb.item href="{{ route('bookings.index', [$event, $bookingOption]) }}">{{ __('Bookings') }}</x-bs::breadcrumb.item>
     @else

--- a/resources/views/bookings/booking_show.blade.php
+++ b/resources/views/bookings/booking_show.blade.php
@@ -13,9 +13,12 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('events.index') }}">{{ __('Events') }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('events.show', $event) }}">{{ $event->name }}</x-bs::breadcrumb.item>
-    <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @include('events.shared.event_breadcrumbs')
+    @can('view', $bookingOption)
+        <x-bs::breadcrumb.item href="{{ route('booking-options.show', [$event, $bookingOption]) }}">{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @else
+        <x-bs::breadcrumb.item>{{ $bookingOption->name }}</x-bs::breadcrumb.item>
+    @endcan
     @can('viewBookings', $bookingOption)
         <x-bs::breadcrumb.item href="{{ route('bookings.index', [$event, $bookingOption]) }}">{{ __('Bookings') }}</x-bs::breadcrumb.item>
     @endcan

--- a/resources/views/event_series/event_series_show.blade.php
+++ b/resources/views/event_series/event_series_show.blade.php
@@ -15,7 +15,11 @@
         <x-bs::breadcrumb.item>{{ __('Event series') }}</x-bs::breadcrumb.item>
     @endcan
     @isset($eventSeries->parentEventSeries)
-        <x-bs::breadcrumb.item href="{{ route('event-series.show', $eventSeries->parentEventSeries) }}">{{ $eventSeries->parentEventSeries->name }}</x-bs::breadcrumb.item>
+        @can('viewAny', $eventSeries->parentEventSeries)
+            <x-bs::breadcrumb.item href="{{ route('event-series.show', $eventSeries->parentEventSeries) }}">{{ $eventSeries->parentEventSeries->name }}</x-bs::breadcrumb.item>
+        @else
+            <x-bs::breadcrumb.item>{{ $eventSeries->parentEventSeries->name }}</x-bs::breadcrumb.item>
+        @endcan
     @endisset
     <x-bs::breadcrumb.item>@yield('title')</x-bs::breadcrumb.item>
 @endsection

--- a/resources/views/event_series/shared/event_series_breadcrumbs.blade.php
+++ b/resources/views/event_series/shared/event_series_breadcrumbs.blade.php
@@ -2,7 +2,11 @@
     /** @var ?\App\Models\EventSeries $eventSeries */
     $parentEventSeries = $eventSeries->parentEventSeries ?? null;
 @endphp
-<x-bs::breadcrumb.item href="{{ route('event-series.index') }}">{{ __('Event series') }}</x-bs::breadcrumb.item>
+@can('viewAny', \App\Models\EventSeries::class)
+    <x-bs::breadcrumb.item href="{{ route('event-series.index') }}">{{ __('Event series') }}</x-bs::breadcrumb.item>
+@else
+    <x-bs::breadcrumb.item>{{ __('Event series') }}</x-bs::breadcrumb.item>
+@endcan
 @isset($parentEventSeries)
     @can('view', $parentEventSeries)
         <x-bs::breadcrumb.item href="{{ route('event-series.show', $parentEventSeries) }}">{{ $parentEventSeries->name }}</x-bs::breadcrumb.item>

--- a/resources/views/events/event_show.blade.php
+++ b/resources/views/events/event_show.blade.php
@@ -15,7 +15,11 @@
         <x-bs::breadcrumb.item>{{ __('Events') }}</x-bs::breadcrumb.item>
     @endcan
     @isset($event->parentEvent)
-        <x-bs::breadcrumb.item href="{{ route('events.show', $event->parentEvent) }}">{{ $event->parentEvent->name }}</x-bs::breadcrumb.item>
+        @can('view', $event->parentEvent)
+            <x-bs::breadcrumb.item href="{{ route('events.show', $event->parentEvent) }}">{{ $event->parentEvent->name }}</x-bs::breadcrumb.item>
+        @else
+            <x-bs::breadcrumb.item>{{ $event->parentEvent->name }}</x-bs::breadcrumb.item>
+        @endcan
     @endisset
     <x-bs::breadcrumb.item>@yield('title')</x-bs::breadcrumb.item>
 @endsection

--- a/resources/views/groups/group_index.blade.php
+++ b/resources/views/groups/group_index.blade.php
@@ -9,11 +9,7 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('events.index') }}">{{ __('Events') }}</x-bs::breadcrumb.item>
-    @isset($event->parentEvent)
-        <x-bs::breadcrumb.item href="{{ route('events.show', $event->parentEvent) }}">{{ $event->parentEvent->name }}</x-bs::breadcrumb.item>
-    @endisset
-    <x-bs::breadcrumb.item href="{{ route('events.show', $event) }}">{{ $event->name }}</x-bs::breadcrumb.item>
+    @include('events.shared.event_breadcrumbs')
     <x-bs::breadcrumb.item>{{ __('Groups') }}</x-bs::breadcrumb.item>
 @endsection
 

--- a/resources/views/locations/location_form.blade.php
+++ b/resources/views/locations/location_form.blade.php
@@ -13,10 +13,7 @@
 @endsection
 
 @section('breadcrumbs')
-    <x-bs::breadcrumb.item href="{{ route('locations.index') }}">{{ __('Locations') }}</x-bs::breadcrumb.item>
-    @isset($location)
-        <x-bs::breadcrumb.item>{{ $location->nameOrAddress }}</x-bs::breadcrumb.item>
-    @endisset
+    @include('locations.shared.location_breadcrumbs')
 @endsection
 
 @section('headline-buttons')


### PR DESCRIPTION
- Fixes #122.
- Use `@include('xxx.shared.xxx_breadcrumbs')` whenever possible.
- Introduce more checks for abilities in breadcrumb paths to ensure that nobody can see links whose target is not accessible for the user.