### PR TITLE
Extend seeders, add tests for migrate:rollback and db:seed

### DIFF
--- a/database/factories/BookingFactory.php
+++ b/database/factories/BookingFactory.php
@@ -25,7 +25,7 @@ class BookingFactory extends Factory
             'city' => fake()->city(),
             'country' => fake()->country(),
             'phone' => fake()->phoneNumber(),
-            'email' => sprintf('%s.%s@%s', Str::slug($firstName), Str::slug($lastName), fake()->unique()->domainName()),
+            'email' => sprintf('%s.%s@%s', Str::slug($firstName), Str::slug($lastName), fake()->domainName()),
             'date_of_birth' => fake()->date(),
             'booked_at' => $this->faker->dateTime(),
             'comment' => $this->faker->optional()->text(),

--- a/database/seeders/BookingOptionSeeder.php
+++ b/database/seeders/BookingOptionSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\BookingOption;
+use App\Models\Event;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class BookingOptionSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        $events = $this->resolveDependency(Event::class, EventSeeder::class);
+
+        // Select about 70% of events to have booking options
+        $selectedEvents = $events->random((int) ($events->count() * 0.7));
+
+        foreach ($selectedEvents as $event) {
+            // Create 1-3 booking options for each selected event
+            BookingOption::factory(random_int(1, 3))
+                ->for($event)
+                ->create();
+        }
+    }
+}

--- a/database/seeders/BookingSeeder.php
+++ b/database/seeders/BookingSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\BookingOption;
+use App\Models\User;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class BookingSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        $users = $this->resolveDependency(User::class, UserSeeder::class);
+        $bookingOptions = $this->resolveDependency(BookingOption::class, BookingOptionSeeder::class);
+
+        foreach ($bookingOptions as $bookingOption) {
+            Booking::factory(random_int(1, $bookingOption->maximum_bookings ?? 99))
+                ->for($bookingOption)
+                ->state(function () use ($users) {
+                    $status = fake()->boolean(80) ? BookingStatus::Confirmed : BookingStatus::Waiting;
+
+                    // Assign a user to the booking with 40% probability.
+                    $bookedByUserId = fake()->boolean(40) ? $users->random()->id : null;
+
+                    return [
+                        'status' => $status,
+                        'booked_by_user_id' => $bookedByUserId,
+                        'booked_at' => fake()->dateTimeBetween('-1 month'),
+                    ];
+                })
+                ->create();
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,50 +2,25 @@
 
 namespace Database\Seeders;
 
-use App\Models\Event;
-use App\Models\EventSeries;
-use App\Models\Location;
-use App\Models\Organization;
-use App\Models\User;
-use App\Models\UserRole;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        $this->call(UserRoleSeeder::class);
+        $this->call([
+            UserRoleSeeder::class,
+            UserSeeder::class, // needs user roles
 
-        $userRoles = UserRole::all();
-        foreach ($userRoles as $userRole) {
-            User::factory(5)
-                ->hasAttached($userRole)
-                ->create();
-        }
+            LocationSeeder::class,
+            OrganizationSeeder::class, // needs locations and users
+            EventSeeder::class, // needs locations, organizations and users
+            EventSeriesSeeder::class, // needs  organizations and users
+            BookingOptionSeeder::class, // needs events
+            BookingSeeder::class, // needs booking options and users
 
-        /** @var Collection<int, Location> $locations */
-        $locations = Location::factory(5)->create();
-        /** @var Location $randomLocation */
-        $randomLocation = fake()->randomElement($locations);
-
-        /** @var Collection<int, Organization> $organizations */
-        $organizations = Organization::factory(5)
-            ->for($randomLocation)
-            ->create();
-        /** @var Organization $randomOrganization */
-        $randomOrganization = fake()->randomElement($organizations);
-
-        Event::factory(5)
-            ->for($randomLocation)
-            ->for($randomOrganization)
-            ->create();
-
-        EventSeries::factory(3)
-            ->for($randomOrganization)
-            ->create();
+            StorageLocationSeeder::class,
+            MaterialSeeder::class, // needs organizations and storage locations
+        ]);
     }
 }

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\Organization;
+use App\Models\User;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Database\Seeders\Traits\SeedsDocuments;
+use Database\Seeders\Traits\SeedsResponsibleUsers;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class EventSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+    use SeedsDocuments;
+    use SeedsResponsibleUsers;
+
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        $locations = $this->resolveDependency(Location::class, LocationSeeder::class);
+        $organizations = $this->resolveDependency(Organization::class, OrganizationSeeder::class);
+        $users = $this->resolveDependency(User::class, UserSeeder::class);
+
+        foreach ($organizations as $organization) {
+            $events = Event::factory(random_int(5, 10))
+                ->recycle($locations)
+                ->state(fn () => ['location_id' => $locations->random()->id])
+                ->for($organization)
+                ->create();
+
+            foreach ($events as $event) {
+                $this->attachResponsibleUsers($event, $users, 50);
+                $this->seedDocuments($event, $users, 50);
+            }
+        }
+    }
+}

--- a/database/seeders/EventSeriesSeeder.php
+++ b/database/seeders/EventSeriesSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\EventSeries;
+use App\Models\Organization;
+use App\Models\User;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Database\Seeders\Traits\SeedsDocuments;
+use Database\Seeders\Traits\SeedsResponsibleUsers;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class EventSeriesSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+    use SeedsDocuments;
+    use SeedsResponsibleUsers;
+
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        $organizations = $this->resolveDependency(Organization::class, OrganizationSeeder::class);
+        $users = $this->resolveDependency(User::class, UserSeeder::class);
+
+        foreach ($organizations as $organization) {
+            $eventSeries = EventSeries::factory(random_int(3, 5))
+                ->for($organization)
+                ->create();
+
+            foreach ($eventSeries as $series) {
+                $this->attachResponsibleUsers($series, $users, 40);
+                $this->seedDocuments($series, $users, 40);
+            }
+        }
+    }
+}

--- a/database/seeders/LocationSeeder.php
+++ b/database/seeders/LocationSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Location;
+use App\Models\User;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Database\Seeders\Traits\SeedsDocuments;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class LocationSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+    use SeedsDocuments;
+
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        $users = $this->resolveDependency(User::class, UserSeeder::class);
+
+        $locations = Location::factory(10)
+            ->create();
+
+        foreach ($locations as $location) {
+            $this->seedDocuments($location, $users, 60);
+        }
+    }
+}

--- a/database/seeders/MaterialSeeder.php
+++ b/database/seeders/MaterialSeeder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\MaterialStatus;
+use App\Models\Material;
+use App\Models\Organization;
+use App\Models\StorageLocation;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class MaterialSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        $organizations = $this->resolveDependency(Organization::class, OrganizationSeeder::class);
+        $storageLocations = $this->resolveDependency(StorageLocation::class, StorageLocationSeeder::class);
+
+        foreach ($organizations as $organization) {
+            $materials = Material::factory(random_int(10, 20))
+                ->state(function () {
+                    return ['name' => fake()->unique()->words(3, true)];
+                })
+                ->for($organization)
+                ->create();
+
+            foreach ($materials as $material) {
+                $chance = fake()->numberBetween(1, 100);
+
+                // 90% get at least one storage location
+                if ($chance <= 90) {
+                    $locationsToAttach = $storageLocations->random(1);
+
+                    // For 20% of all materials, 2-4 storage locations more are added.
+                    if (fake()->numberBetween(1, 100) <= 20) {
+                        $additionalCount = random_int(2, 4);
+                        $additionalLocations = $storageLocations
+                            ->whereNotIn('id', $locationsToAttach->pluck('id'))
+                            ->random(min($storageLocations->count() - 1, $additionalCount));
+                        $locationsToAttach = $locationsToAttach->concat($additionalLocations);
+                    }
+
+                    foreach ($locationsToAttach as $location) {
+                        $material->storageLocations()->attach($location->id, [
+                            'material_status' => fake()->randomElement(MaterialStatus::cases()),
+                            'stock' => fake()->optional()->numberBetween(1, 100),
+                            'remarks' => fake()->optional()->text(),
+                        ]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/database/seeders/OrganizationSeeder.php
+++ b/database/seeders/OrganizationSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Location;
+use App\Models\Organization;
+use App\Models\User;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Database\Seeders\Traits\SeedsDocuments;
+use Database\Seeders\Traits\SeedsResponsibleUsers;
+use Illuminate\Database\Seeder;
+
+class OrganizationSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+    use SeedsDocuments;
+    use SeedsResponsibleUsers;
+
+    public function run(): void
+    {
+        $locations = $this->resolveDependency(Location::class, LocationSeeder::class);
+        $allUsers = $this->resolveDependency(User::class, UserSeeder::class);
+
+        $organizations = Organization::factory(5)
+            ->recycle($locations)
+            ->state(fn () => ['location_id' => $locations->random()->id])
+            ->create();
+
+        foreach ($organizations as $organization) {
+            $this->attachResponsibleUsers($organization, $allUsers, 70);
+            $this->seedDocuments($organization, $allUsers, 70);
+        }
+    }
+}

--- a/database/seeders/StorageLocationSeeder.php
+++ b/database/seeders/StorageLocationSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\StorageLocation;
+use Illuminate\Database\Seeder;
+use Random\RandomException;
+
+class StorageLocationSeeder extends Seeder
+{
+    /**
+     * @throws RandomException
+     */
+    public function run(): void
+    {
+        foreach (range(1, 5) as $index) {
+            $parent = StorageLocation::factory()->create([
+                'name' => 'Warehouse ' . $index,
+            ]);
+
+            $this->createChildren($parent, 1);
+        }
+    }
+
+    /**
+     * @throws RandomException
+     */
+    private function createChildren(StorageLocation $parent, int $currentLevel): void
+    {
+        if ($currentLevel >= 3) {
+            return;
+        }
+
+        $childCount = random_int(0, 4);
+        $prefix = match ($currentLevel) {
+            1 => 'Shelf ',
+            2 => 'Bin ',
+            default => 'Level ',
+        };
+
+        for ($i = 1; $i <= $childCount; $i++) {
+            $child = StorageLocation::factory()->create([
+                'name' => $parent->name . ' - ' . $prefix . $i,
+                'parent_storage_location_id' => $parent->id,
+            ]);
+
+            $this->createChildren($child, $currentLevel + 1);
+        }
+    }
+}

--- a/database/seeders/Traits/ResolvesSeederDependencies.php
+++ b/database/seeders/Traits/ResolvesSeederDependencies.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders\Traits;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Seeder;
+
+trait ResolvesSeederDependencies
+{
+    /**
+     * @template T of Model
+     *
+     * @param class-string<T> $modelClass
+     * @param class-string<Seeder> $seederClass
+     *
+     * @return Collection<int, T>
+     */
+    protected function resolveDependency(string $modelClass, string $seederClass): Collection
+    {
+        if ($modelClass::count() === 0) {
+            $this->call($seederClass);
+        }
+
+        /** @phpstan-ignore-next-line return.type */
+        return $modelClass::all();
+    }
+}

--- a/database/seeders/Traits/SeedsDocuments.php
+++ b/database/seeders/Traits/SeedsDocuments.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders\Traits;
+
+use App\Enums\FileType;
+use App\Models\Document;
+use App\Models\Event;
+use App\Models\EventSeries;
+use App\Models\Location;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Random\RandomException;
+
+trait SeedsDocuments
+{
+    /**
+     * @param Collection<int, User> $users
+     *
+     * @throws RandomException
+     */
+    protected function seedDocuments(Event|EventSeries|Location|Organization $model, Collection $users, int $probability): void
+    {
+        if (fake()->boolean($probability)) {
+            $count = random_int(1, 4);
+
+            Document::factory($count)
+                ->forReference($model)
+                ->state(fn () => [
+                    'file_type' => FileType::Text,
+                    'uploaded_by_user_id' => $users->random()->id,
+                ])
+                ->create();
+        }
+    }
+}

--- a/database/seeders/Traits/SeedsResponsibleUsers.php
+++ b/database/seeders/Traits/SeedsResponsibleUsers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders\Traits;
+
+use App\Models\Event;
+use App\Models\EventSeries;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Random\RandomException;
+
+trait SeedsResponsibleUsers
+{
+    /**
+     * @param Collection<int, User> $users
+     *
+     * @throws RandomException
+     */
+    protected function attachResponsibleUsers(Event|EventSeries|Organization $model, Collection $users, int $probability): void
+    {
+        if (fake()->boolean($probability)) {
+            $model->responsibleUsers()->attach(
+                $users->random(min($users->count(), random_int(1, 3)))
+                    ->pluck('id')
+                    ->toArray(),
+                [
+                    'publicly_visible' => fake()->boolean(),
+                    'position' => fake()->jobTitle(),
+                    'sort' => 0,
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/UserRoleSeeder.php
+++ b/database/seeders/UserRoleSeeder.php
@@ -24,9 +24,9 @@ class UserRoleSeeder extends Seeder
      */
     private function createUserRole(string $name, array $abilities): void
     {
-        $userRole = new UserRole();
-        $userRole->name = $name;
-        $userRole->abilities = Ability::values($abilities);
-        $userRole->save();
+        UserRole::updateOrCreate(
+            ['name' => $name],
+            ['abilities' => Ability::values($abilities)]
+        );
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use App\Models\UserRole;
+use Database\Seeders\Traits\ResolvesSeederDependencies;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    use ResolvesSeederDependencies;
+
+    public function run(): void
+    {
+        $userRoles = $this->resolveDependency(UserRole::class, UserRoleSeeder::class);
+
+        foreach ($userRoles as $userRole) {
+            User::factory(5)
+                ->hasAttached($userRole)
+                ->create();
+        }
+    }
+}

--- a/tests/Feature/Console/Commands/DatabaseCommandsTest.php
+++ b/tests/Feature/Console/Commands/DatabaseCommandsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Console\Commands;
+
+use Tests\TestCase;
+
+class DatabaseCommandsTest extends TestCase
+{
+    public function testMigrationsAndRollback(): void
+    {
+        $this->artisan('migrate')
+            /** @phpstan-ignore method.nonObject */
+            ->expectsOutputToContain('Nothing to migrate.')
+            ->assertSuccessful();
+
+        $this->artisan('migrate:rollback')
+            /** @phpstan-ignore method.nonObject */
+            ->expectsOutputToContain('Rolling back migrations.')
+            ->doesntExpectOutputToContain('FAIL')
+            ->assertSuccessful();
+    }
+
+    public function testSeeders(): void
+    {
+        $this->artisan('db:seed')
+            /** @phpstan-ignore method.nonObject */
+            ->expectsOutputToContain('Seeding database.')
+            ->doesntExpectOutputToContain('FAIL')
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
- Add seeders for booking options, bookings, documents, responsible users, storage locations and materials
- Extend existing seeders