### PR TITLE
Adjust exports to DIN A4

### DIFF
--- a/app/Exports/BookingsExportSpreadsheet.php
+++ b/app/Exports/BookingsExportSpreadsheet.php
@@ -23,13 +23,16 @@ class BookingsExportSpreadsheet extends Spreadsheet
     ) {
         parent::__construct();
 
+        $headerColumns = $this->getHeaderColumns();
+        $worksheet = $this->getActiveSheet();
         self::fillSheetFromCollection(
-            $this->getActiveSheet(),
+            $worksheet,
             $this->bookingOption->name,
             $this->bookings,
-            $this->getHeaderColumns(),
+            $headerColumns,
             fn (Booking $booking) => $this->getColumnsForRow($booking)
         );
+        self::setAutoSizeForColumns($worksheet, count($headerColumns));
     }
 
     /**

--- a/app/Exports/GroupsExportSpreadsheet.php
+++ b/app/Exports/GroupsExportSpreadsheet.php
@@ -6,12 +6,13 @@ use App\Exports\Traits\ExportsToExcel;
 use App\Models\Booking;
 use App\Models\Event;
 use App\Models\Group;
-use Illuminate\Support\Collection;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class GroupsExportSpreadsheet extends Spreadsheet
 {
     use ExportsToExcel;
+
+    private const int COLUMN_COUNT = 5;
 
     public function __construct(
         private readonly Event $event,
@@ -24,15 +25,60 @@ class GroupsExportSpreadsheet extends Spreadsheet
             'groups.bookings',
         ]);
 
-        /** @var int $rowCount */
-        $rowCount = $this->event->groups
-            ->max(fn (Group $group) => $group->bookings->count());
+        $worksheet = $this->getActiveSheet();
+        self::setTitle($worksheet, $this->event->name);
 
+        $worksheet->setCellValue('A1', $this->event->name);
+        self::formatHeadline($worksheet, self::COLUMN_COUNT);
+
+        $currentReportRow = 3;
+        $bookings = $this->prepareBookings();
+        $chunks = $this->event->groups->chunk(self::COLUMN_COUNT);
+        foreach ($chunks as $chunk) {
+            // Header row
+            $worksheet->fromArray([$chunk->map(fn (Group $group) => $group->name)->toArray()], startCell: 'A' . $currentReportRow);
+            self::formatBold($worksheet, $currentReportRow, self::COLUMN_COUNT);
+            $currentReportRow++;
+
+            // Rows for the bookings
+            /** @phpstan-ignore-next-line cast.int count(array) is an integer. */
+            $maxBookingsInChunk = (int) $chunk->max(fn (Group $group) => count($bookings[$group->id]));
+            for ($i = 0; $i < $maxBookingsInChunk; $i++) {
+                $col = 1;
+                foreach ($chunk as $group) {
+                    $name = $bookings[$group->id][$i] ?? null;
+                    if ($name !== null) {
+                        $worksheet->getCell([$col, $currentReportRow])->setValue($name);
+                    }
+                    $col++;
+                }
+                $currentReportRow++;
+            }
+
+            // Empty row.
+            $currentReportRow++;
+        }
+
+        self::setPageLayout($worksheet);
+        self::setColumnWidths($worksheet, [
+            'A' => 5.2,
+            'B' => 5.2,
+            'C' => 5.2,
+            'D' => 5.2,
+            'E' => 5.2,
+        ]);
+    }
+
+    /**
+     * @return array<int, string[]>
+     */
+    private function prepareBookings(): array
+    {
         $parentEvent = $this->event->parentEvent;
-
         $bookings = [];
         foreach ($this->event->groups as $group) {
-            $bookings[$group->id] = Booking::sort($group->bookings, $this->sort)
+            /** @var string[] $groupMembers */
+            $groupMembers = Booking::sort($group->bookings, $this->sort)
                 ->map(
                     function (Booking $booking) use ($group, $parentEvent) {
                         $name = $booking->first_name . ' ' . $booking->last_name;
@@ -49,23 +95,9 @@ class GroupsExportSpreadsheet extends Spreadsheet
                 )
                 ->values()
                 ->toArray();
+            $bookings[$group->id] = $groupMembers;
         }
 
-        /**
-         * @var Collection<int, int> $rows
-         */
-        $rows = Collection::range(0, $rowCount - 1);
-        self::fillSheetFromCollection(
-            $this->getActiveSheet(),
-            $this->event->name,
-            $rows,
-            /** @phpstan-ignore-next-line argument.type */
-            $this->event->groups
-                ->map(fn (Group $group) => $group->name)
-                ->toArray(),
-            fn (int $row) => $this->event->groups
-                ->map(fn (Group $group) => $bookings[$group->id][$row] ?? null)
-                ->toArray(),
-        );
+        return $bookings;
     }
 }

--- a/app/Exports/MaterialsExportSpreadsheet.php
+++ b/app/Exports/MaterialsExportSpreadsheet.php
@@ -33,8 +33,9 @@ class MaterialsExportSpreadsheet extends Spreadsheet
             }
         }
 
+        $worksheet = $this->getActiveSheet();
         self::fillSheetFromCollection(
-            $this->getActiveSheet(),
+            $worksheet,
             __('Materials'),
             $materialsWithStorageData,
             $this->getHeaderColumns(),
@@ -43,6 +44,15 @@ class MaterialsExportSpreadsheet extends Spreadsheet
                 return $this->getColumnsForRow($material, $storageLocation);
             }
         );
+        self::setColumnWidths($worksheet, [
+            'A' => 5.5,
+            'B' => 4.5,
+            'C' => 3,
+            'D' => 5,
+            'E' => 2,
+            'F' => 2,
+            'G' => 4,
+        ]);
     }
 
     /**

--- a/app/Exports/StorageLocationsExportSpreadsheet.php
+++ b/app/Exports/StorageLocationsExportSpreadsheet.php
@@ -19,6 +19,7 @@ class StorageLocationsExportSpreadsheet extends Spreadsheet
 
         $this->setMetaData(__('Storage locations'));
 
+        $worksheet = $this->getActiveSheet();
         self::fillSheetFromCollection(
             $this->getActiveSheet(),
             __('Storage locations'),
@@ -26,6 +27,13 @@ class StorageLocationsExportSpreadsheet extends Spreadsheet
             $this->getHeaderColumns(),
             fn (StorageLocation $storageLocation) => $this->getColumnsForRow($storageLocation)
         );
+        self::setColumnWidths($worksheet, [
+            'A' => 5,
+            'B' => 5,
+            'C' => 4,
+            'D' => 4,
+            'E' => 8,
+        ]);
     }
 
     /**

--- a/app/Exports/Traits/ExportsToExcel.php
+++ b/app/Exports/Traits/ExportsToExcel.php
@@ -5,6 +5,7 @@ namespace App\Exports\Traits;
 use Closure;
 use Illuminate\Support\Collection;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 /**
@@ -33,21 +34,21 @@ trait ExportsToExcel
         Collection $collection,
         array $headerColumns,
         Closure $rowProvider
-    ): Worksheet {
-        $worksheet->setTitle(substr(str_replace(['*', ':', '/', '\\', '?', '[', ']'], '', $title), 0, 31));
+    ): void {
+        self::setTitle($worksheet, $title);
+        self::setPageLayout($worksheet);
+
         $worksheet->fromArray([
-            [$title],
+            [$title], // Row 1
             [],
-            $headerColumns,
+            $headerColumns, // Row 3
             ...$collection->map($rowProvider),
         ]);
 
         $columnCount = count($headerColumns);
         self::formatHeadline($worksheet, $columnCount);
-        $worksheet->setAutoFilter([1, 3, $columnCount, 3]);
-        self::setAutoSizeForColumns($worksheet, $columnCount);
-
-        return $worksheet;
+        self::formatHeaderColumns($worksheet, $columnCount);
+        self::setTextWrapping($worksheet, $columnCount, $collection->count() + 3);
     }
 
     public static function formatHeadline(Worksheet $worksheet, int $columnCount): void
@@ -58,10 +59,56 @@ trait ExportsToExcel
         $worksheet->getCell('A1')->getStyle()->getFont()->getColor()->setRGB('44546A');
     }
 
+    public static function formatHeaderColumns(Worksheet $worksheet, int $columnCount): void
+    {
+        self::formatBold($worksheet, 3, $columnCount);
+        $worksheet->setAutoFilter([1, 3, $columnCount, 3]);
+    }
+
+    public static function formatBold(Worksheet $worksheet, int $rowIndex, int $columnCount): void
+    {
+        $worksheet->getStyle([1, $rowIndex, $columnCount, $rowIndex])
+            ->getFont()
+            ->setBold(true);
+    }
+
+    /**
+     * @param array<string, float|int> $columns
+     */
+    public static function setColumnWidths(Worksheet $worksheet, array $columns): void
+    {
+        foreach ($columns as $column => $width) {
+            $worksheet->getColumnDimension($column)->setAutoSize(false);
+            $worksheet->getColumnDimension($column)->setWidth($width, 'cm');
+        }
+    }
+
     public static function setAutoSizeForColumns(Worksheet $worksheet, int $columnCount): void
     {
         foreach (range(1, $columnCount) as $column) {
             $worksheet->getColumnDimensionByColumn($column)->setAutoSize(true);
         }
+    }
+
+    public static function setPageLayout(Worksheet $worksheet): void
+    {
+        $worksheet->getPageSetup()
+            ->setPaperSize(PageSetup::PAPERSIZE_A4)
+            ->setOrientation(PageSetup::ORIENTATION_LANDSCAPE);
+        $worksheet->getPageMargins()
+            ->setLeft(0.39) // ~1cm
+            ->setRight(0.39);
+    }
+
+    public static function setTextWrapping(Worksheet $worksheet, int $columnCount, int $rowCount): void
+    {
+        $worksheet->getStyle([1, 1, $columnCount, $rowCount])
+            ->getAlignment()
+            ->setWrapText(true);
+    }
+
+    public static function setTitle(Worksheet $worksheet, string $title): void
+    {
+        $worksheet->setTitle(substr(str_replace(['*', ':', '/', '\\', '?', '[', ']'], '', $title), 0, 31));
     }
 }


### PR DESCRIPTION
- Closes #37 for groups.
- Closes #109 for materials.
- Adjust exports for storage locations to DIN A4, text-wrapping.
- Adjust bookings to format as DIN A4 - may be wider if there are many columns.
