### PR TITLE
Improve static analysis (PHPUnit extension, ignore only specific errors instead of full line)

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ To setup/update your development environment:
 For development, we use
 - [ESlint](https://eslint.org/) for the JavaScript code style check
 - [Laravel Debugbar](https://github.com/fruitcake/laravel-debugbar) for debugging utility
-- [Laravel Pint](https://laravel.com/docs/13.x/pint) for the PHP code style check
+- [Laravel Pint](https://laravel.com/docs/13.x/pint) with [portavice/laravel-pint-config](https://github.com/portavice/laravel-pint-config) for the PHP code style check
 - [Laravel Translatable String Exporter](https://github.com/kkomelin/laravel-translatable-string-exporter) to extract translations strings from PHP and Blade
-- [PHPStan](https://phpstan.org/) with [Larastan](https://github.com/larastan/larastan) and [strict rules extension](https://github.com/phpstan/phpstan-strict-rules) for static analysis
+- [PHPStan](https://phpstan.org/) with
+  - [strict rules for PHP](https://github.com/phpstan/phpstan-strict-rules),
+  - [Larastan](https://github.com/larastan/larastan),
+  - [PHPUnit extension](https://github.com/phpstan/phpstan-phpunit)
+  for static analysis
 - [PHPUnit](https://docs.phpunit.de/) with [ParaTest](https://github.com/paratestphp/paratest) for Unit tests
 - [Stylelint](https://stylelint.io/) for the SASS code style check
-- [Vite](https://laravel.com/docs/13.x/vite#introduction) with [Laravel](https://github.com/laravel/vite-plugin) and [static copy plugin](https://github.com/sapphi-red/vite-plugin-static-copy) for compiling and copying assets
+- [Vite](https://laravel.com/docs/13.x/vite) with [Laravel](https://github.com/laravel/vite-plugin) and [static copy plugin](https://github.com/sapphi-red/vite-plugin-static-copy) for compiling and copying assets
 
 ### Code Style
 Run `composer cs` to check compliance with the code style

--- a/app/Enums/Traits/NamedOption.php
+++ b/app/Enums/Traits/NamedOption.php
@@ -19,7 +19,7 @@ trait NamedOption
      */
     private function valueOrName(): int|string
     {
-        /** @phpstan-ignore-next-line property.notFound */
+        /** @phpstan-ignore property.notFound */
         return $this->value ?? $this->name;
     }
 
@@ -49,7 +49,7 @@ trait NamedOption
 
     public static function exists(int|string $value): bool
     {
-        /** @phpstan-ignore-next-line staticMethod.notFound */
+        /** @phpstan-ignore staticMethod.notFound */
         return self::tryFrom($value) !== null;
     }
 
@@ -80,7 +80,7 @@ trait NamedOption
      */
     public static function values(?array $array = null): array
     {
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore return.type */
         return array_map(
             static fn (self $enumCase) => $enumCase->valueOrName(),
             $array ?? self::cases()

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -105,16 +105,16 @@ class Handler extends ExceptionHandler
 
             // Handle 429 (Too Many Requests) errors.
             if ($e instanceof ThrottleRequestsException) {
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore argument.type */
                 $tokenId = (int) strtok($request->bearerToken(), '|');
                 Log::info(sprintf('API: Too many requests for token %s', $tokenId));
                 return $this->renderApiError(
                     Response::HTTP_TOO_MANY_REQUESTS,
                     sprintf(
                         __('Access limited to %d request(s) per %d minute(s).'),
-                        /** @phpstan-ignore-next-line argument.type */
+                        /** @phpstan-ignore argument.type */
                         config('api.throttle.max_attempts', 60),
-                        /** @phpstan-ignore-next-line argument.type */
+                        /** @phpstan-ignore argument.type */
                         config('api.throttle.decay_minutes', 1)
                     ),
                     headers: $e->getHeaders()

--- a/app/Exports/GroupsExportSpreadsheet.php
+++ b/app/Exports/GroupsExportSpreadsheet.php
@@ -41,7 +41,7 @@ class GroupsExportSpreadsheet extends Spreadsheet
             $currentReportRow++;
 
             // Rows for the bookings
-            /** @phpstan-ignore-next-line cast.int count(array) is an integer. */
+            /** @phpstan-ignore cast.int (count(array) is an integer) */
             $maxBookingsInChunk = (int) $chunk->max(fn (Group $group) => count($bookings[$group->id]));
             for ($i = 0; $i < $maxBookingsInChunk; $i++) {
                 $col = 1;

--- a/app/Exports/Traits/ExportsToExcel.php
+++ b/app/Exports/Traits/ExportsToExcel.php
@@ -16,7 +16,7 @@ trait ExportsToExcel
     public function setMetaData(string $title): void
     {
         $this->getProperties()
-            /** @phpstan-ignore-next-line binaryOp.invalid */
+            /** @phpstan-ignore binaryOp.invalid, binaryOp.invalid */
             ->setCreator(config('app.name') . ' - ' . config('app.owner'))
             ->setTitle($title);
     }

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -23,7 +23,7 @@ class ConfirmablePasswordController extends Controller
     {
         if (
             !Auth::guard('web')->validate([
-                /** @phpstan-ignore-next-line property.nonObject */
+                /** @phpstan-ignore property.nonObject */
                 'email' => $request->user()->email,
                 'password' => $request->password,
             ])

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -13,13 +13,11 @@ class EmailVerificationNotificationController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        /** @phpstan-ignore-next-line property.nonObject */
-        if ($request->user()->hasVerifiedEmail()) {
+        if ($request->user()?->hasVerifiedEmail() === true) {
             return redirect()->intended(route('dashboard'));
         }
 
-        /** @phpstan-ignore-next-line property.nonObject */
-        $request->user()->sendEmailVerificationNotification();
+        $request->user()?->sendEmailVerificationNotification();
 
         return back()
             ->with('success', __('A new verification link has been sent to the e-mail address you provided during registration.'));

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -11,9 +11,10 @@ class EmailVerificationPromptController extends Controller
 {
     public function __invoke(Request $request): RedirectResponse|View
     {
-        /** @phpstan-ignore-next-line property.nonObject */
-        return $request->user()->hasVerifiedEmail()
-            ? redirect()->intended(route('dashboard'))
-            : view('auth.verify-email');
+        if ($request->user()?->hasVerifiedEmail() === true) {
+            return redirect()->intended(route('dashboard'));
+        }
+
+        return view('auth.verify-email');
     }
 }

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -43,7 +43,7 @@ class NewPasswordController extends Controller
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function ($user) use ($request) {
                 $user->forceFill([
-                    /** @phpstan-ignore-next-line argument.type */
+                    /** @phpstan-ignore argument.type */
                     'password' => Hash::make($request->password),
                     'remember_token' => Str::random(60),
                 ])->save();
@@ -59,7 +59,7 @@ class NewPasswordController extends Controller
                     ? redirect()->route('login')->with('status', __($status))
                     : back()
                         ->withInput($request->only('email'))
-                        /** @phpstan-ignore-next-line argument.type */
+                        /** @phpstan-ignore argument.type */
                         ->withErrors(['email' => __($status)]);
     }
 }

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -39,7 +39,7 @@ class BookingController extends Controller
 
         /** @var \Illuminate\Database\Eloquent\Builder<Booking> $bookingsQuery */
         $bookingsQuery = Booking::buildQueryFromRequest($bookingOption->bookings())
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             ->with([
                 'bookedByUser',
                 'groups' => fn (BelongsToMany $groups) => $groups->where('event_id', '=', $event->id),
@@ -235,7 +235,7 @@ class BookingController extends Controller
     {
         $this->authorize('restore', $booking);
 
-        /** @phpstan-ignore-next-line staticMethod.dynamicCall */
+        /** @phpstan-ignore staticMethod.dynamicCall */
         if ($booking->restore()) {
             Session::flash('success', __('Restored successfully.'));
         }

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -235,6 +235,7 @@ class BookingController extends Controller
     {
         $this->authorize('restore', $booking);
 
+        /** @phpstan-ignore-next-line staticMethod.dynamicCall */
         if ($booking->restore()) {
             Session::flash('success', __('Restored successfully.'));
         }

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -23,8 +23,7 @@ class DocumentController extends Controller
 
         return view('documents.document_index', [
             'documents' => Document::buildQueryFromRequest()
-                /** @see Document::scopeVisibleForUser() */
-                ->visibleForUser()
+                ->visibleForUser() /** @see Document::scopeVisibleForUser() */
                 ->with([
                     'reference',
                     'uploadedByUser',

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -24,7 +24,7 @@ class EventController extends Controller
         return view('events.event_index', [
             ...$this->formValuesForFilter(),
             'events' => Event::buildQueryFromRequest()
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore argument.type */
                 ->with([
                     'bookingOptions' => static fn (HasMany $query) => $query->withCount([
                         'bookingsConfirmed',

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -30,7 +30,7 @@ class GroupController extends Controller
             return $this->streamExcelExport(
                 new GroupsExportSpreadsheet(
                     $event,
-                    /** @phpstan-ignore-next-line argument.type */
+                    /** @phpstan-ignore argument.type */
                     $request->validated('sort', 'name')
                 ),
                 str_replace(' ', '-', $fileName) . '.xlsx',
@@ -48,9 +48,9 @@ class GroupController extends Controller
     {
         $this->authorize('create', Group::class);
 
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type */
         $method = GroupGenerationMethod::from($request->validated('method'));
-        /** @phpstan-ignore-next-line cast.int */
+        /** @phpstan-ignore cast.int */
         $groupsCount = (int) $request->validated('groups_count');
 
         /** @var int[] $bookingOptionIds */

--- a/app/Http/Controllers/PersonalAccessTokenController.php
+++ b/app/Http/Controllers/PersonalAccessTokenController.php
@@ -28,7 +28,7 @@ class PersonalAccessTokenController extends Controller
     {
         $this->authorize('create', PersonalAccessToken::class);
 
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type, argument.type */
         $newAccessToken = PersonalAccessToken::createTokenFromValidated($request->user(), $request->validated());
         Session::flash('success', __('Your personal access token is :token. Please make a note of it (e.g. in your password safe) - you will not be able to view it again.', [
             'token' => $newAccessToken->plainTextToken,

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -54,7 +54,7 @@ class UserController extends Controller
         $user = new User();
         if ($user->fillAndSave($request->validated())) {
             Session::flash('success', __(':name created successfully.', ['name' => $user->name]));
-            if ($request->validated('send_notification') !== null) {
+            if ($request->validated('send_notification') === true) {
                 $user->sendAccountCreatedNotification();
             }
             return $this->actionAwareRedirect(

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -88,7 +88,7 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type */
         return Str::lower($this->input('email')) . '|' . $this->ip();
     }
 }

--- a/app/Http/Requests/DocumentRequest.php
+++ b/app/Http/Requests/DocumentRequest.php
@@ -83,27 +83,27 @@ class DocumentRequest extends FormRequest
     private function getReference(): Model
     {
         if ($this->routeIs('documents.update')) {
-            /** @phpstan-ignore-next-line property.nonObject */
+            /** @phpstan-ignore property.nonObject */
             return $this->document->reference;
         }
 
         if ($this->routeIs('events.documents.store')) {
-            /** @phpstan-ignore-next-line return.type */
+            /** @phpstan-ignore return.type */
             return $this->event;
         }
 
         if ($this->routeIs('event-series.documents.store')) {
-            /** @phpstan-ignore-next-line return.type */
+            /** @phpstan-ignore return.type */
             return $this->event_series;
         }
 
         if ($this->routeIs('locations.documents.store')) {
-            /** @phpstan-ignore-next-line return.type */
+            /** @phpstan-ignore return.type */
             return $this->location;
         }
 
         if ($this->routeIs('organizations.documents.store')) {
-            /** @phpstan-ignore-next-line return.type */
+            /** @phpstan-ignore return.type */
             return $this->organization;
         }
 

--- a/app/Http/Requests/GenerateGroupsRequest.php
+++ b/app/Http/Requests/GenerateGroupsRequest.php
@@ -44,9 +44,9 @@ class GenerateGroupsRequest extends FormRequest
      */
     public function rules(): array
     {
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type */
         $selectedBookingOptionIds = array_intersect(
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             array_map(static fn ($i) => is_numeric($i) ? (int) $i : null, $this->input('booking_option_id', [])),
             $this->event->getBookingOptions()->pluck('id')->toArray()
         );
@@ -101,7 +101,7 @@ class GenerateGroupsRequest extends FormRequest
             'exclude_parent_group_id' => __('Exclude members of groups'),
         ];
 
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type */
         foreach (range(0, count($this->input('exclude_parent_group_id')) - 1) as $id) {
             $attributes['exclude_parent_group_id.' . $id] = __('Exclude members of groups');
         }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -21,6 +21,11 @@ class UserRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        if ($this->routeIs('users.store')) {
+            $this->merge([
+                'send_notification' => $this->boolean('send_notification'),
+            ]);
+        }
         $this->merge([
             'user_role_id' => $this->input('user_role_id', []), // Force array!
         ]);

--- a/app/Listeners/CacheOpenApiDocListener.php
+++ b/app/Listeners/CacheOpenApiDocListener.php
@@ -39,7 +39,7 @@ class CacheOpenApiDocListener
         return str_replace(
             array_keys($replacements),
             array_values($replacements),
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             file_get_contents(base_path('open-api.yaml'))
         );
     }

--- a/app/Livewire/Groups/ManageGroups.php
+++ b/app/Livewire/Groups/ManageGroups.php
@@ -61,7 +61,7 @@ class ManageGroups extends Component
     {
         $this->event = $event;
         $this->loadData();
-        /** @phpstan-ignore-next-line assign.propertyType */
+        /** @phpstan-ignore assign.propertyType */
         $this->bookingOptionIds = $this->event->getBookingOptions()->pluck('id')->toArray();
 
         $this->loadSettingsFromSession();
@@ -223,7 +223,7 @@ class ManageGroups extends Component
     {
         $bookings = $this->event->getBookings();
         if (count($this->showFields) > 0) {
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             $bookings->load([
                 'formFieldValues' => fn (HasMany $formFieldValues) => $formFieldValues
                     ->whereIn('form_field_id', $this->showFields),
@@ -232,7 +232,7 @@ class ManageGroups extends Component
         $this->groups = $this->groups
             ->map(function (Group $group) use ($bookings) {
                 $group['bookings'] = $this->sortBookingsInGroup(
-                    /** @phpstan-ignore-next-line argument.type */
+                    /** @phpstan-ignore argument.type */
                     $bookings->filter(fn (Booking $booking) => $booking->getGroup($this->event)?->is($group))
                 );
 

--- a/app/Livewire/Users/SearchUsers.php
+++ b/app/Livewire/Users/SearchUsers.php
@@ -56,10 +56,8 @@ class SearchUsers extends Component
         return User::query()
             ->where(
                 fn (Builder $query) => $query
-                    /** @see User::scopeName() */
-                    ->name(...$searchTerms)
-                    /** @see User::scopeEmail() */
-                    ->orWhere(fn (Builder $query2) => $query2->email(...$searchTerms))
+                    ->name(...$searchTerms) /** @see User::scopeName() */
+                    ->orWhere(fn (Builder $query2) => $query2->email(...$searchTerms)) /** @see User::scopeEmail() */
             )
             ->whereNotIn('id', $this->selectedUsers->keys())
             ->orderBy('last_name')

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -263,7 +263,7 @@ class Booking extends Model
         }
 
         $formFieldValue->forceCast();
-        /** @phpstan-ignore-next-line assign.propertyType */
+        /** @phpstan-ignore assign.propertyType */
         $formFieldValue->value = $value;
         return $formFieldValue->save();
     }
@@ -289,7 +289,7 @@ class Booking extends Model
         $value = $this->getFieldValue($formField);
 
         if ($formField->isSingleCheckbox()) {
-            /** @phpstan-ignore-next-line cast.int */
+            /** @phpstan-ignore cast.int */
             $value = ((int) $value === 1)
                 ? __('Yes')
                 : __('No');
@@ -302,15 +302,15 @@ class Booking extends Model
             }
 
             $value = match ($formField->type) {
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore argument.type */
                 FormElementType::Date => formatDate($value),
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore argument.type */
                 FormElementType::DateTime => formatDateTime($value),
                 default => $value,
             };
         }
 
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore return.type */
         return $value;
     }
 
@@ -325,7 +325,7 @@ class Booking extends Model
                 'bookingOption.formFields',
             ]),
         ])
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             ->addInfo([
                 'Author' => config('app.owner'),
                 'Title' => implode(' ', [

--- a/app/Models/BookingOption.php
+++ b/app/Models/BookingOption.php
@@ -167,13 +167,9 @@ class BookingOption extends Model
         return in_array($restriction->value, $this->restrictions ?? [], true);
     }
 
-    /**
-     * @param int|string $value
-     *
-     * @phpstan-ignore-next-line method.childParameterType
-     */
     public function resolveRouteBinding($value, $field = null): static
     {
+        /** @var int|string $value */
         /** @var Event $event */
         $event = request()->route('event');
 

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -112,7 +112,7 @@ class Document extends Model
     {
         $this->fill($validatedData);
 
-        /** @phpstan-ignore-next-line identical.alwaysFalse */
+        /** @phpstan-ignore identical.alwaysFalse */
         if ($this->approval_status === null) {
             // Set the approval status to the default value if not contained in the request.
             $this->approval_status = ApprovalStatus::WaitingForApproval;
@@ -126,11 +126,11 @@ class Document extends Model
 
             $targetDirectory = $this->reference->getDocumentStoragePath();
             if ($this->exists) {
-                /** @phpstan-ignore-next-line */
+                /** @phpstan-ignore assign.propertyType */
                 $this->path = $file->storeAs($targetDirectory, $this->id . '-' . $file->getClientOriginalName());
             } else {
                 $tempFileName = 'tmp-' . Carbon::now()->format('Ymd-His') . '-' . $file->getClientOriginalName();
-                /** @phpstan-ignore-next-line */
+                /** @phpstan-ignore assign.propertyType */
                 $this->path = $file->storeAs($targetDirectory, $tempFileName);
                 $this->save();
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -178,7 +178,7 @@ class Event extends Model
 
     public function findOrCreateGroup(int|string $groupIndex): Group
     {
-        /** @phpstan-ignore-next-line */
+        /** @phpstan-ignore return.type */
         return $this->groups()
             ->firstOrCreate([
                 'name' => __('Group') . ' ' . $groupIndex,
@@ -304,7 +304,7 @@ class Event extends Model
     {
         return [
             ...self::defaultValuesForFilters(),
-            /** @phpstan-ignore-next-line array.invalidKey */
+            /** @phpstan-ignore array.invalidKey */
             config('query-builder.parameters.sort') => '-period',
         ];
     }

--- a/app/Models/QueryBuilder/BuildsQueryFromRequest.php
+++ b/app/Models/QueryBuilder/BuildsQueryFromRequest.php
@@ -32,7 +32,7 @@ trait BuildsQueryFromRequest
         }
         /** @phpstan-var non-empty-array<AllowedSort|string> $defaultSorts */
 
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type */
         return QueryBuilder::for($subject ?? self::class)
             ->allowedFilters(...self::allowedFilters())
             ->allowedSorts(...self::allowedSorts())
@@ -48,7 +48,7 @@ trait BuildsQueryFromRequest
 
         return [
             ...self::defaultValuesForFilters(),
-            /** @phpstan-ignore-next-line array.invalidKey */
+            /** @phpstan-ignore array.invalidKey */
             config('query-builder.parameters.sort') => $defaultSort instanceof AllowedSort ? $defaultSort->getName() : null,
         ];
     }

--- a/app/Models/QueryBuilder/Filterable.php
+++ b/app/Models/QueryBuilder/Filterable.php
@@ -23,7 +23,7 @@ trait Filterable
      */
     public static function defaultValuesForFilters(): array
     {
-        /** @phpstan-ignore-next-line binaryOp.invalid */
+        /** @phpstan-ignore binaryOp.invalid */
         $filterSuffix = config('query-builder.parameters.filter') . '.';
 
         $defaults = [];

--- a/app/Models/Traits/HasIdForRouting.php
+++ b/app/Models/Traits/HasIdForRouting.php
@@ -6,18 +6,14 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait HasIdForRouting
 {
-    /**
-     * @param int|string $value
-     */
-    /** @phpstan-ignore method.childParameterType */
     public function resolveRouteBinding($value, $field = null): ?static
     {
+        /** @var int|string $value */
         try {
-            /** @phpstan-ignore-next-line */
+            /** @phpstan-ignore return.type */
             return self::query()->findOrFail($value);
         } catch (ModelNotFoundException $exception) {
             // Set $value as model IDs for proper exception handling.
-            /** @phpstan-ignore argument.type */
             throw $exception->setModel($exception->getModel(), [$value]);
         }
     }

--- a/app/Models/Traits/HasSlugForRouting.php
+++ b/app/Models/Traits/HasSlugForRouting.php
@@ -28,13 +28,9 @@ trait HasSlugForRouting
         return 'slug';
     }
 
-    /**
-     * @param int|string $value
-     *
-     * @phpstan-ignore-next-line method.childParameterType
-     */
-    public function resolveRouteBinding($value, $field = null): static
+    public function resolveRouteBinding($value, $field = null): ?static
     {
+        /** @var int|string $value */
         try {
             return static::query()
                  ->where('slug', '=', $value)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -226,7 +226,7 @@ class User extends Authenticatable implements MustVerifyEmail
             $abilities->add($userRole->abilities);
         }
 
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore return.type */
         return $abilities->flatten()
             ->unique();
     }

--- a/app/Notifications/AccountCreatedNotification.php
+++ b/app/Notifications/AccountCreatedNotification.php
@@ -19,10 +19,10 @@ class AccountCreatedNotification extends Notification
         $adminUser = Auth::user();
 
         $mailMessage = (new MailMessage())
-            /** @phpstan-ignore-next-line binaryOp.invalid */
+            /** @phpstan-ignore binaryOp.invalid */
             ->subject(config('app.name') . ': ' . __('Account created for you'))
             ->greeting($this->user->greeting)
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             ->line(__(':admin_name has created an account for :app_name for you.', [
                 'admin_name' => $adminUser->name ?? __('someone'),
                 'app_name' => config('app.name'),

--- a/app/Notifications/BookingConfirmation.php
+++ b/app/Notifications/BookingConfirmation.php
@@ -20,7 +20,7 @@ class BookingConfirmation extends Notification
     {
         $mail = $this->booking->prepareMailMessage()
             ->subject(
-                /** @phpstan-ignore-next-line binaryOp.invalid */
+                /** @phpstan-ignore binaryOp.invalid */
                 config('app.name')
                 . ': '
                 . __('Booking no. :id', [
@@ -41,7 +41,7 @@ class BookingConfirmation extends Notification
             if (isset($this->booking->price) && $this->booking->price > 0) {
                 $mail->line(__('Please transfer :price to the following bank account by :date:', [
                     'price' => formatDecimal($this->booking->price) . ' €',
-                    /** @phpstan-ignore-next-line argument.type */
+                    /** @phpstan-ignore argument.type */
                     'date' => formatDate($this->booking->payment_deadline),
                 ]));
                 $mail->lines($this->booking->bookingOption->event->organization->bank_account_lines);

--- a/app/Notifications/PaymentReminderNotification.php
+++ b/app/Notifications/PaymentReminderNotification.php
@@ -20,7 +20,7 @@ class PaymentReminderNotification extends Notification implements ShouldQueue
     {
         return $this->booking->prepareMailMessage()
             ->subject(
-                /** @phpstan-ignore-next-line binaryOp.invalid */
+                /** @phpstan-ignore binaryOp.invalid */
                 config('app.name')
                 . ': '
                 . __('Pending payment for booking no. :id', [
@@ -29,11 +29,11 @@ class PaymentReminderNotification extends Notification implements ShouldQueue
             )
             ->line(__('we have received your booking for :name dated :date, but have not yet been able to confirm receipt of payment.', [
                 'name' => $this->booking->name,
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore argument.type */
                 'date' => formatDate($this->booking->booked_at),
             ]))
             ->line(__('Please transfer :price to the following bank account as soon as possible:', [
-                /** @phpstan-ignore-next-line argument.type */
+                /** @phpstan-ignore argument.type */
                 'price' => formatDecimal($this->booking->price) . ' €',
             ]))
             ->lines($this->booking->bookingOption->event->organization->bank_account_lines);

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -18,14 +18,14 @@ class ResetPasswordNotification extends ResetPassword
     protected function buildMailMessage($url): MailMessage
     {
         return (new MailMessage())
-            /** @phpstan-ignore-next-line binaryOp.invalid */
+            /** @phpstan-ignore binaryOp.invalid */
             ->subject(config('app.name') . ': ' . __('Reset password'))
             ->greeting($this->user->greeting)
             ->line(__('You are receiving this email because we received a password reset request for your account.'))
             ->action(__('Reset password'), $url)
-            /** @phpstan-ignore-next-line  argument.type */
+            /** @phpstan-ignore  argument.type */
             ->line(__('This link will expire in :count minutes.', [
-                /** @phpstan-ignore-next-line binaryOp.invalid */
+                /** @phpstan-ignore binaryOp.invalid */
                 'count' => config('auth.passwords.' . config('auth.defaults.passwords') . '.expire'),
             ]))
             ->line(__('If you did not request a password reset, no further action is required.'));

--- a/app/Notifications/VerifyEmailNotification.php
+++ b/app/Notifications/VerifyEmailNotification.php
@@ -16,7 +16,7 @@ class VerifyEmailNotification extends VerifyEmail
     protected function buildMailMessage($url): MailMessage
     {
         return (new MailMessage())
-            /** @phpstan-ignore-next-line binaryOp.invalid */
+            /** @phpstan-ignore binaryOp.invalid */
             ->subject(config('app.name') . ': ' . __('Verify e-mail address'))
             ->greeting($this->user->greeting)
             ->line(__('Please click the button below to verify your e-mail address.'))

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -154,7 +154,7 @@ class UserPolicy
      */
     public function register(?User $user): Response
     {
-        /** @phpstan-ignore-next-line argument.type */
+        /** @phpstan-ignore argument.type */
         return $this->response(config('app.features.registration'));
     }
 

--- a/app/Traits/LoadsPropertiesFromSession.php
+++ b/app/Traits/LoadsPropertiesFromSession.php
@@ -18,9 +18,9 @@ trait LoadsPropertiesFromSession
     {
         $value = Session::get($this->getSessionKey($propertyName));
 
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore return.type */
         return match ($expectedType) {
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             'int[]', => is_array($value) ? array_map('intval', $value) : null,
             'string' => is_string($value) ? $value : null,
             'string[]' => is_array($value) ? $value : null,

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.9",
         "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^13.1",
         "portavice/laravel-pint-config": "^3.0",
@@ -81,6 +82,7 @@
             "@composer install --optimize-autoloader --no-dev"
         ],
         "stan": [
+            "Composer\\Config::disableProcessTimeout",
             "phpstan analyse --memory-limit=1G"
         ],
         "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "669b879e8ebb8817718b8c8d615a59f8",
+    "content-hash": "24b11ae7f18e0dc4bec35bd6727015ed",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -8826,6 +8826,62 @@
                 }
             ],
             "time": "2026-04-29T13:31:09+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.32"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
+            },
+            "time": "2026-02-14T09:05:21+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",

--- a/database/factories/Traits/BelongsToLocation.php
+++ b/database/factories/Traits/BelongsToLocation.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 /**
  * @mixin Factory
  *
- * @phpstan-ignore-next-line missingType.generics
+ * @phpstan-ignore missingType.generics
  */
 trait BelongsToLocation
 {

--- a/database/factories/Traits/BelongsToOrganization.php
+++ b/database/factories/Traits/BelongsToOrganization.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 /**
  * @mixin Factory
  *
- * @phpstan-ignore-next-line missingType.generics
+ * @phpstan-ignore missingType.generics
  */
 trait BelongsToOrganization
 {

--- a/database/factories/Traits/HasVisibility.php
+++ b/database/factories/Traits/HasVisibility.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 /**
  * @mixin Factory
  *
- * @phpstan-ignore-next-line missingType.generics
+ * @phpstan-ignore missingType.generics
  */
 trait HasVisibility
 {

--- a/database/seeders/Traits/ResolvesSeederDependencies.php
+++ b/database/seeders/Traits/ResolvesSeederDependencies.php
@@ -22,7 +22,7 @@ trait ResolvesSeederDependencies
             $this->call($seederClass);
         }
 
-        /** @phpstan-ignore-next-line return.type */
+        /** @phpstan-ignore return.type */
         return $modelClass::all();
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,17 +7,18 @@ parameters:
     checkUnionTypes: true
     editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
     ignoreErrors:
-         - '#Class App\\Models\\.* uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types: TFactory#'
-         - '#Method App\\Models\\.*::\w+\(\) return type with generic class Illuminate\\Database\\Eloquent\\Casts\\Attribute does not specify its types: TGet, TSet#'
-         - '#Method App\\Models\\.*::\w+\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\\w+ does not specify its types: \w+#'
-         - '#Method App\\Models\\.*::scope\w+\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types#'
-         - '#Method App\\Models\\.*::scope\w+\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types: TModel#'
-         - '#return type with generic class Illuminate\\Testing\\TestResponse does not specify its types: TResponse#'
-         - # Ignore dynamic calls for methods annotated with @method
-             identifier: staticMethod.dynamicCall
-             paths:
-                - app
-                - tests/Feature/Livewire/*
+        - '#Class App\\Models\\.* uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types: TFactory#'
+        - '#Method App\\Models\\.*::\w+\(\) return type with generic class Illuminate\\Database\\Eloquent\\Casts\\Attribute does not specify its types: TGet, TSet#'
+        - '#Method App\\Models\\.*::\w+\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\\w+ does not specify its types: \w+#'
+        - '#Method App\\Models\\.*::scope\w+\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types#'
+        - '#Method App\\Models\\.*::scope\w+\(\) return type with generic class Illuminate\\Database\\Eloquent\\Builder does not specify its types: TModel#'
+        - '#return type with generic class Illuminate\\Testing\\TestResponse does not specify its types: TResponse#'
+        - # Ignore false positives for Eloquent Builder, Request and TestResponse.
+            identifier: staticMethod.dynamicCall
+            messages:
+                - '#^Dynamic call to static method Illuminate\\Database\\Eloquent\\Builder<.*>::(.*)\(\)\.$#'
+                - '#^Dynamic call to static method Illuminate\\Http\\Request::validate\(\)\.$#'
+                - '#^Dynamic call to static method Illuminate\\Testing\\TestResponse<.*>::assert.*\(\).$#'
     level: 9
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,8 @@
 includes:
     - ./vendor/larastan/larastan/extension.neon
     - ./vendor/nesbot/carbon/extension.neon
+    - ./vendor/phpstan/phpstan-phpunit/extension.neon
+    - ./vendor/phpstan/phpstan-phpunit/rules.neon
     - ./vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:

--- a/tests/Feature/Console/Commands/SendPaymentRemindersCommandTest.php
+++ b/tests/Feature/Console/Commands/SendPaymentRemindersCommandTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Console\Commands;
 use App\Console\Commands\SendPaymentRemindersCommand;
 use App\Enums\BookingStatus;
 use App\Models\Booking;
+use App\Models\User;
 use App\Notifications\PaymentReminderNotification;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -42,9 +43,11 @@ class SendPaymentRemindersCommandTest extends TestCase
             /** @phpstan-ignore method.nonObject */
             ->expectsOutputToContain("Sent reminder to {$booking->email} for booking {$booking->id}.")
             ->assertSuccessful();
-        Notification::assertSentTo(new AnonymousNotifiable(), PaymentReminderNotification::class, static function ($notification) use ($booking) {
-            /** @phpstan-ignore-next-line argument.type */
-            return str_contains($notification->toMail($booking->bookedByUser)->render(), $booking->bookedByUser->greeting);
+
+        /** @var User $user */
+        $user = $booking->bookedByUser;
+        Notification::assertSentTo(new AnonymousNotifiable(), PaymentReminderNotification::class, static function ($notification) use ($user) {
+            return str_contains($notification->toMail($user)->render(), $user->greeting);
         });
         Notification::assertCount(1);
     }
@@ -97,7 +100,7 @@ class SendPaymentRemindersCommandTest extends TestCase
         return self::createBooking($bookingOption, [
             'paid_at' => null,
             'deleted_at' => null,
-            /** @phpstan-ignore-next-line method.nonObject */
+            /** @phpstan-ignore method.notFound */
             'booked_at' => Carbon::today()->subWeekDays(11),
         ]);
     }

--- a/tests/Feature/Http/BookingControllerTest.php
+++ b/tests/Feature/Http/BookingControllerTest.php
@@ -402,9 +402,9 @@ class BookingControllerTest extends TestCase
         ];
         $this->assertUserCanPutOnlyWithAbility($route, $data, Ability::EditPaymentStatus, $route, $route);
 
-        /** @phpstan-ignore-next-line staticMethod.dynamicCall */
+        /** @phpstan-ignore staticMethod.dynamicCall */
         self::assertEquals($bookings->count(), $bookingOption->bookings()->whereNotNull('paid_at')->count());
-        /** @phpstan-ignore-next-line staticMethod.dynamicCall */
+        /** @phpstan-ignore staticMethod.dynamicCall */
         self::assertEquals($bookings2->count(), $bookingOption->bookings()->whereNull('paid_at')->count());
     }
 

--- a/tests/Feature/Http/BookingOptionControllerTest.php
+++ b/tests/Feature/Http/BookingOptionControllerTest.php
@@ -102,14 +102,14 @@ class BookingOptionControllerTest extends TestCase
                 fn (BookingOptionFactory $factory) => $factory->availabilityStartingInFuture(),
                 fn (BookingOption $bookingOption) => [
                     __('Bookings are not possible yet.'),
-                    /** @phpstan-ignore-next-line argument.type */
+                    /** @phpstan-ignore argument.type */
                     __('The booking period starts at :date.', ['date' => formatDateTime($bookingOption->available_from)]),
                 ],
             ],
             [
                 fn (BookingOptionFactory $factory) => $factory->availabilityEndedInPast(),
                 fn (BookingOption $bookingOption) => [
-                    /** @phpstan-ignore-next-line argument.type */
+                    /** @phpstan-ignore argument.type */
                     __('The booking period ended at :date.', ['date' => formatDateTime($bookingOption->available_until)]),
                     __('Bookings are not possible anymore.'),
                 ],

--- a/tests/Feature/Http/MaterialControllerTest.php
+++ b/tests/Feature/Http/MaterialControllerTest.php
@@ -131,7 +131,7 @@ class MaterialControllerTest extends TestCase
     {
         return [
             'storage_location_id' => self::createStorageLocation()->id,
-            /** @phpstan-ignore-next-line property.nonObject */
+            /** @phpstan-ignore property.nonObject */
             'material_status' => $this->faker->randomElement(MaterialStatus::cases())->value,
             'stock' => $this->faker->optional()->numberBetween(1, 100),
             'remarks' => $this->faker->optional()->text(),

--- a/tests/Traits/GeneratesTestData.php
+++ b/tests/Traits/GeneratesTestData.php
@@ -202,7 +202,7 @@ trait GeneratesTestData
     protected static function createDocuments(): Collection
     {
         return Document::factory()
-            /** @phpstan-ignore-next-line argument.type */
+            /** @phpstan-ignore argument.type */
             ->for(fake()->randomElement([
                 self::createEvent(Visibility::Public),
                 self::createEventSeries(Visibility::Private),
@@ -361,7 +361,7 @@ trait GeneratesTestData
     public static function createUserResponsibleFor(Event|EventSeries|Organization $responsibleFor): User
     {
         return User::factory()
-            /** @phpstan-ignore-next-line match.unhandled */
+            /** @phpstan-ignore match.unhandled */
             ->hasAttached($responsibleFor, ['publicly_visible' => true], match ($responsibleFor::class) {
                 Event::class => 'responsibleForEvents',
                 EventSeries::class => 'responsibleForEventSeries',


### PR DESCRIPTION
- Ignore `identifier: staticMethod.dynamicCall` only for specific classes known for false positives
- Include additional rules from [PHPUnit extension](https://github.com/phpstan/phpstan-phpunit)
- Avoid `@phpstan-ignore-next-line`